### PR TITLE
Feat: Create interactive index for industry primers

### DIFF
--- a/primers/index.html
+++ b/primers/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Industry Primers</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Industry Primers</h1>
+        <input type="text" id="searchBar" placeholder="Search for primers...">
+
+        <div class="primer-entry" data-title="Aerospace Defense">
+            <h2 class="primer-title"><a href="aerospace_defense.md">Aerospace Defense</a></h2>
+            <div class="primer-summary">
+                <p>The Aerospace & Defense (A&D) sector comprises companies that research, design, manufacture, and support aircraft, spacecraft, defense systems, and related components and services. It's characterized by long product cycles, high technological complexity, significant R&D investment, strong government influence (especially in defense), and stringent safety and performance standards.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Automotive">
+            <h2 class="primer-title"><a href="automotive.md">Automotive</a></h2>
+            <div class="primer-summary">
+                <p>The automotive industry encompasses the design, development, manufacturing, marketing, and selling of motor vehicles. It is one of the world's largest economic sectors by revenue, characterized by high capital intensity, significant R&D investment, complex global supply chains, strong branding, and extensive regulation.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Consumer Products">
+            <h2 class="primer-title"><a href="consumer_products.md">Consumer Products</a></h2>
+            <div class="primer-summary">
+                <p>The consumer products sector encompasses companies that manufacture and/or sell goods directly to consumers. It's a vast and diverse industry, broadly categorized into:</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Corporate Credit Rating Fundamentals">
+            <h2 class="primer-title"><a href="corporate_credit_rating_fundamentals.md">Corporate Credit Rating Fundamentals</a></h2>
+            <div class="primer-summary">
+                <p>Credit ratings are opinions about the creditworthiness of an issuer (like a corporation or government) or a specific debt obligation. They assess the likelihood that a borrower will meet its financial obligations as they come due. The two most prominent global credit rating agencies are Standard & Poor's (S&P) and Moody's Investors Service. Fitch Ratings is another significant player.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Energy Oil Gas">
+            <h2 class="primer-title"><a href="energy_oil_gas.md">Energy Oil Gas</a></h2>
+            <div class="primer-summary">
+                <p>The oil and gas industry is involved in the exploration, production (upstream), transportation (midstream), and refining and marketing (downstream) of crude oil and natural gas. It's a global, capital-intensive, and historically cyclical industry with significant geopolitical influence.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Financial Institutions">
+            <h2 class="primer-title"><a href="financial_institutions.md">Financial Institutions</a></h2>
+            <div class="primer-summary">
+                <p>Financial institutions (FIs) are entities that provide financial services for their clients or members. They are crucial intermediaries in the economy, facilitating capital flows, managing risk, and enabling transactions. The sector is characterized by high regulation, sensitivity to economic conditions and interest rates, and the use of leverage.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Healthcare">
+            <h2 class="primer-title"><a href="healthcare.md">Healthcare</a></h2>
+            <div class="primer-summary">
+                <p>The healthcare industry encompasses a wide range of companies providing medical services, manufacturing medical products, developing pharmaceuticals, and facilitating healthcare delivery. It's characterized by significant regulation, scientific innovation, and a blend of public and private funding models.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Industrials">
+            <h2 class="primer-title"><a href="industrials.md">Industrials</a></h2>
+            <div class="primer-summary">
+                <p>The industrials sector is a broad and diverse category encompassing companies involved in the production and distribution of machinery, equipment, and supplies used in manufacturing, construction, and resource extraction. It also includes companies providing related services like transportation, logistics, and commercial services. This sector is often seen as a bellwether for the broader economy due to its sensitivity to business investment and construction activity.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Media">
+            <h2 class="primer-title"><a href="media.md">Media</a></h2>
+            <div class="primer-summary">
+                <p>The media industry encompasses companies involved in the creation, aggregation, and distribution of information and entertainment content. It's a dynamic sector that has undergone significant transformation due to technological advancements, particularly the internet and mobile devices.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Real Estate">
+            <h2 class="primer-title"><a href="real_estate.md">Real Estate</a></h2>
+            <div class="primer-summary">
+                <p>The real estate sector encompasses companies that own, develop, operate, manage, and/or invest in income-producing properties, as well as those that provide real estate-related services. It's a significant component of the global economy, characterized by its capital intensity, illiquidity of assets, and sensitivity to economic cycles and interest rates.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Technology">
+            <h2 class="primer-title"><a href="technology.md">Technology</a></h2>
+            <div class="primer-summary">
+                <p>The technology sector is characterized by rapid innovation, short product lifecycles, and intense competition. It encompasses a wide array of sub-sectors, including:</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Telecommunications">
+            <h2 class="primer-title"><a href="telecommunications.md">Telecommunications</a></h2>
+            <div class="primer-summary">
+                <p>The telecommunications (telecom) industry provides the infrastructure and services that enable voice, data, and video transmission. Historically dominated by state-owned monopolies providing fixed-line voice services, the sector has undergone massive transformation due to deregulation, privatization, and technological innovation.</p>
+            </div>
+        </div>
+
+        <div class="primer-entry" data-title="Utilities">
+            <h2 class="primer-title"><a href="utilities.md">Utilities</a></h2>
+            <div class="primer-summary">
+                <p>The utilities sector comprises companies that provide essential public services related to electricity, natural gas, and water. Historically, these were often vertically integrated, regulated monopolies operating within exclusive service territories. While deregulation has introduced competition in some segments (especially power generation and retail supply in certain regions), the transmission and distribution (T&D) components typically remain regulated monopolies due to their natural monopoly characteristics (i.e., it's inefficient to build duplicate power lines or water pipes).</p>
+            </div>
+        </div>
+
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/primers/script.js
+++ b/primers/script.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const searchBar = document.getElementById('searchBar');
+    const primerEntries = document.querySelectorAll('.primer-entry');
+
+    // Search functionality
+    searchBar.addEventListener('keyup', (e) => {
+        const searchTerm = e.target.value.toLowerCase();
+
+        primerEntries.forEach(entry => {
+            const title = entry.dataset.title.toLowerCase();
+            if (title.includes(searchTerm)) {
+                entry.style.display = '';
+            } else {
+                entry.style.display = 'none';
+            }
+        });
+    });
+
+    // Collapsible section functionality
+    primerEntries.forEach(entry => {
+        const titleElement = entry.querySelector('.primer-title');
+        const summaryElement = entry.querySelector('.primer-summary');
+
+        if (titleElement && summaryElement) {
+            titleElement.addEventListener('click', (event) => {
+                // Prevent link navigation if the click is not directly on the <a> tag,
+                // or allow navigation if it is. For simplicity, let's toggle summary visibility.
+                // The link will work independently.
+                summaryElement.classList.toggle('active');
+            });
+        }
+    });
+});

--- a/primers/styles.css
+++ b/primers/styles.css
@@ -1,0 +1,76 @@
+body {
+    font-family: sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+.container {
+    max-width: 800px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+h1 {
+    text-align: center;
+    color: #2c3e50;
+    margin-bottom: 20px;
+}
+
+#searchBar {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.primer-entry {
+    background-color: #ecf0f1;
+    border: 1px solid #bdc3c7;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    padding: 0; /* Remove padding here, will be on title/summary */
+    overflow: hidden; /* Contains the floated elements if any, and ensures borders wrap correctly */
+}
+
+.primer-title {
+    background-color: #3498db;
+    color: white;
+    padding: 10px 15px;
+    margin: 0;
+    cursor: pointer;
+    font-size: 1.2em;
+    border-bottom: 1px solid #2980b9; /* Separator line */
+}
+
+.primer-title a {
+    color: white;
+    text-decoration: none;
+    display: block; /* Makes the whole title area clickable for the link */
+}
+
+.primer-title a:hover {
+    text-decoration: underline;
+}
+
+.primer-summary {
+    padding: 10px 15px;
+    display: none; /* Hidden by default */
+    background-color: #fff; /* White background for summary */
+    border-top: 1px solid #bdc3c7; /* Separator from title if needed, but title has bottom border */
+}
+
+.primer-summary p {
+    margin-top: 0;
+}
+
+.primer-summary.active {
+    display: block;
+}


### PR DESCRIPTION
Adds an `index.html` page to the `primers/` directory that provides an interactive overview of all available industry primers.

Features include:
- Listing of all primers with links to the source markdown files.
- Collapsible summaries for each primer, extracted from the initial overview section of the markdown.
- A search bar to filter primers by title.

Includes accompanying `styles.css` for presentation and `script.js` for interactivity (search and collapsible sections).