### PR TITLE
Add index.html Markdown viewers for content directories

### DIFF
--- a/Behavioral_Finance/index.html
+++ b/Behavioral_Finance/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Behavioral_Finance</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Behavioral_Finance";
+        const filesInDir = ["AGENTS.MD", "Case_Studies.md", "Key_Concepts.md", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Fintech/index.html
+++ b/Fintech/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Fintech</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Fintech";
+        const filesInDir = ["AGENTS.MD", "AI_in_Finance.md", "Blockchain_in_Finance.md", "Cybersecurity_in_Fintech.md", "Insurtech.md", "Introduction_to_Fintech.md", "Open_Banking_and_APIs.md", "Payment_Systems_and_Digital_Currencies.md", "README.md", "Regtech.md", "Robo_Advisors.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Interactive_Notebooks/Financial_Modeling/index.html
+++ b/Interactive_Notebooks/Financial_Modeling/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Financial_Modeling</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Financial_Modeling";
+        const filesInDir = ["README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Interactive_Notebooks/Legal_Analysis/index.html
+++ b/Interactive_Notebooks/Legal_Analysis/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Legal_Analysis</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Legal_Analysis";
+        const filesInDir = ["README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Interactive_Notebooks/Valuation_Components/index.html
+++ b/Interactive_Notebooks/Valuation_Components/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Valuation_Components</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Valuation_Components";
+        const filesInDir = ["README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Interactive_Notebooks/index.html
+++ b/Interactive_Notebooks/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Interactive_Notebooks</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Interactive_Notebooks";
+        const filesInDir = ["AGENTS.MD", "README.md"];
+        const subDirsInfo = [{"name": "Financial_Modeling", "readmePath": "Financial_Modeling/README.md"}, {"name": "Legal_Analysis", "readmePath": "Legal_Analysis/README.md"}, {"name": "Valuation_Components", "readmePath": "Valuation_Components/README.md"}];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Market_Analysis_Quick_Start/index.html
+++ b/Market_Analysis_Quick_Start/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Market_Analysis_Quick_Start</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Market_Analysis_Quick_Start";
+        const filesInDir = ["01_Capital_Market_Terms.md", "02_Key_Market_Products.md", "03_Understanding_Trading_Levels_and_Spreads.md", "04_Valuation_Rules_of_Thumb.md", "05_Peer_Comparison_and_Benchmarking.md", "AGENTS.MD", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Professional_Development/index.html
+++ b/Professional_Development/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Professional_Development</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Professional_Development";
+        const filesInDir = ["AGENTS.MD", "Critical_Thinking_in_Financial_Analysis.md", "Effective_Communication_for_Analysts.md", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Risk_Management/Credit_Risk/index.html
+++ b/Risk_Management/Credit_Risk/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Credit_Risk</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Credit_Risk";
+        const filesInDir = ["CRM_01_Fundamentals_of_Credit_Risk.md", "CRM_02_Credit_Analysis_Process_and_Tools.md", "CRM_03_Credit_Scoring_and_Rating_Models.md", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Risk_Management/Market_Risk/index.html
+++ b/Risk_Management/Market_Risk/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Market_Risk</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Market_Risk";
+        const filesInDir = ["MRM_01_Introduction_to_Market_Risk.md", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Risk_Management/Operational_Risk/index.html
+++ b/Risk_Management/Operational_Risk/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Operational_Risk</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Operational_Risk";
+        const filesInDir = ["ORM_01_Introduction_to_Operational_Risk.md", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Risk_Management/index.html
+++ b/Risk_Management/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Risk_Management</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Risk_Management";
+        const filesInDir = ["01_Introduction_to_Risk_Management.md", "02_Risk_Identification_and_Assessment_Frameworks.md", "03_Risk_Reporting_and_Dashboards.md", "04_Risk_Governance_and_Culture.md", "AGENTS.MD", "README.md"];
+        const subDirsInfo = [{"name": "Credit_Risk", "readmePath": "Credit_Risk/README.md"}, {"name": "Market_Risk", "readmePath": "Market_Risk/README.md"}, {"name": "Operational_Risk", "readmePath": "Operational_Risk/README.md"}];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/Toolkits_and_Checklists/index.html
+++ b/Toolkits_and_Checklists/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Directory Viewer - Toolkits_and_Checklists</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="../assets/css/simple_viewer.css">
+</head>
+<body>
+    <div id="sidebar">
+        <div id="up-link-container">
+            <!-- Up link will be dynamically generated -->
+        </div>
+        <h3>Navigation</h3>
+        <ul id="file-list">
+            <!-- File list will be populated by JavaScript -->
+        </ul>
+    </div>
+    <div id="content-area" class="markdown-body">
+        <p>Loading content...</p>
+    </div>
+
+    <script>
+        const contentDisplay = document.getElementById('content-area');
+        const fileListDisplay = document.getElementById('file-list');
+        const pageTitle = document.querySelector('title');
+
+        const directoryName = "Toolkits_and_Checklists";
+        const filesInDir = ["AGENTS.MD", "Basic_Financial_Ratios_Calculator_Guide.md", "Credit_Analysis_Due_Diligence_Checklist.md", "README.md"];
+        const subDirsInfo = [];
+        const relativePathToRoot = "../";
+        const parentIndexExists = true;
+
+        document.addEventListener('DOMContentLoaded', async function() {
+            pageTitle.textContent = `Viewer - ${directoryName}`;
+
+            let fileLinksHtml = `<li><a href="#" data-md-src="README.md" class="nav-link active">README.md (Main)</a></li>`;
+
+            const sortedFiles = filesInDir.sort((a, b) => {
+                if (a.toLowerCase() === 'readme.md') return -1;
+                if (b.toLowerCase() === 'readme.md') return 1;
+                return a.localeCompare(b);
+            });
+
+            sortedFiles.forEach(file => {
+                if (file.toLowerCase() !== 'readme.md' && file.toLowerCase() !== 'agents.md' && file.endsWith('.md')) {
+                    fileLinksHtml += `<li><a href="#" data-md-src="${file}" class="nav-link">${file}</a></li>`;
+                }
+            });
+
+            subDirsInfo.forEach(subdir => {
+                if (subdir.readmePath) {
+                     fileLinksHtml += `<li class="subdirectory-group"><h4>${subdir.name}/</h4></li>`;
+                     fileLinksHtml += `<li><a href="#" data-md-src="${subdir.readmePath}" class="nav-link">&nbsp;&nbsp;&nbsp;README.md</a></li>`;
+                }
+            });
+            fileListDisplay.innerHTML = fileLinksHtml;
+
+            const upLinkContainer = document.getElementById('up-link-container');
+            let upLink = '';
+            if (relativePathToRoot === "../") {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub</a>`;
+            } else if (parentIndexExists) {
+                 upLink = `<a href="${relativePathToRoot}index.html">&laquo; Up to Parent Directory</a>`;
+            } else {
+                upLink = `<a href="${relativePathToRoot}home.html">&laquo; Back to Main Hub (Fallback)</a>`;
+            }
+            upLinkContainer.innerHTML = upLink;
+
+            fileListDisplay.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    document.querySelectorAll('#file-list .nav-link').forEach(l => l.classList.remove('active'));
+                    this.classList.add('active');
+                    const mdSrc = this.getAttribute('data-md-src');
+                    loadMarkdown(mdSrc);
+                });
+            });
+
+            if (filesInDir.includes('README.md')) {
+                await loadMarkdown('README.md');
+            } else {
+                const firstLink = fileListDisplay.querySelector('.nav-link');
+                if (firstLink) {
+                    firstLink.classList.add('active');
+                    await loadMarkdown(firstLink.getAttribute('data-md-src'));
+                } else {
+                    contentDisplay.innerHTML = "<p>No Markdown files found to display.</p>";
+                }
+            }
+        });
+
+        async function loadMarkdown(mdPath) {
+            if (!contentDisplay) {
+                console.error("Content display element not found.");
+                return;
+            }
+            if (typeof marked === 'undefined') {
+                console.error("Marked.js library not found.");
+                contentDisplay.innerHTML = "<p>Error: Markdown renderer not available.</p>";
+                return;
+            }
+
+            try {
+                const response = await fetch(mdPath);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${mdPath}: ${response.status} ${response.statusText}`);
+                }
+                const markdownText = await response.text();
+                contentDisplay.innerHTML = marked.parse(markdownText);
+                contentDisplay.scrollTop = 0;
+            } catch (error) {
+                console.error("Error loading or parsing Markdown:", error);
+                contentDisplay.innerHTML = `<p>Error loading content for ${mdPath}.</p><p><small>${error.message}</small></p>`;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/assets/css/simple_viewer.css
+++ b/assets/css/simple_viewer.css
@@ -1,0 +1,105 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    display: flex;
+    height: 100vh;
+    background-color: #f4f4f4;
+}
+
+#sidebar {
+    width: 250px;
+    background-color: #333;
+    color: white;
+    padding: 15px;
+    overflow-y: auto;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+#sidebar h3 {
+    margin-top: 0;
+    color: #fff;
+    border-bottom: 1px solid #555;
+    padding-bottom: 10px;
+}
+
+#sidebar ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#sidebar li a {
+    color: #ddd;
+    text-decoration: none;
+    display: block;
+    padding: 8px 0;
+    transition: background-color 0.2s;
+}
+
+#sidebar li a:hover, #sidebar li a.active {
+    color: #fff;
+    background-color: #555;
+}
+
+#sidebar .subdirectory-group {
+    margin-top: 10px;
+    padding-top: 5px;
+    border-top: 1px dashed #555;
+}
+
+#sidebar .subdirectory-group h4 {
+    color: #bbb;
+    font-size: 0.9em;
+    margin-bottom: 5px;
+}
+
+
+#content-area {
+    flex-grow: 1;
+    padding: 20px;
+    overflow-y: auto;
+    background-color: #fff;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+/* Basic styles for rendered markdown */
+.markdown-body h1, .markdown-body h2, .markdown-body h3, .markdown-body h4 {
+    color: #333;
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+    padding-bottom: 0.2em;
+    border-bottom: 1px solid #eee;
+}
+.markdown-body h1 { font-size: 2em; }
+.markdown-body h2 { font-size: 1.75em; }
+.markdown-body h3 { font-size: 1.5em; }
+.markdown-body h4 { font-size: 1.25em; }
+.markdown-body p { margin-bottom: 1em; line-height: 1.6; }
+.markdown-body ul, .markdown-body ol { margin-left: 20px; margin-bottom: 1em; }
+.markdown-body li { margin-bottom: 0.5em; }
+.markdown-body table { border-collapse: collapse; width: auto; margin-bottom: 1em; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.markdown-body th, .markdown-body td { border: 1px solid #ccc; padding: 8px 10px; text-align: left; }
+.markdown-body th { background-color: #f0f0f0; font-weight: bold; }
+.markdown-body code:not(pre code) { background-color: #eee; padding: 2px 5px; border-radius: 3px; font-family: monospace; font-size: 0.95em; }
+.markdown-body pre { background-color: #2d2d2d; color: #f1f1f1; padding: 15px; border-radius: 5px; overflow-x: auto; }
+.markdown-body pre code { background-color: transparent; color: inherit; padding: 0; font-size: 0.9em; }
+.markdown-body blockquote { border-left: 4px solid #ddd; padding-left: 15px; color: #555; margin-left: 0; }
+.markdown-body a { color: #007bff; text-decoration: none; }
+.markdown-body a:hover { text-decoration: underline; }
+.markdown-body img { max-width: 100%; height: auto; border-radius: 4px; }
+
+#up-link-container {
+    padding: 10px 15px;
+    background-color: #222;
+    border-top: 1px solid #555;
+}
+
+#up-link-container a {
+    color: #00aaff;
+    text-decoration: none;
+    font-weight: bold;
+}
+#up-link-container a:hover {
+    text-decoration: underline;
+}

--- a/primers/AGENTS.MD
+++ b/primers/AGENTS.MD
@@ -1,0 +1,51 @@
+# AGENTS.MD - Primers Section
+
+## Inherits From
+This document inherits general principles from the root `AGENTS.MD` file. Please review that first.
+
+## 1. Purpose and Scope of this Directory
+The `/primers/` directory contains detailed industry-specific analysis guides. Each primer aims to provide a comprehensive overview of an industry, including its structure, long-term trends, business cycles, key credit metrics, rating considerations, specific risk factors, and monitoring/underwriting tips.
+
+The primary interactive entry point for this section is `primers/index.html`.
+
+## 2. Content Structure and Types
+*   **Main Navigator:** `primers/index.html` serves as the main navigation page for all primers.
+    *   It currently uses a "card" based layout, where each card links to a full HTML version of the primer (e.g., `primers/html/aerospace_defense.html`).
+    *   It also includes search functionality.
+    *   *Developer Note:* `primers/index.html` had a merge conflict noted in its source. The active version links to separate HTML files for each primer's details. An alternative, commented-out version suggested embedding all primer content with accordions directly within `primers/index.html` or linking to the raw `.md` files. For now, the active version (linking to `primers/html/*.html`) is the standard to follow.
+*   **Individual Primer Markdown Files:** Each industry primer is originally authored as a Markdown file (e.g., `primers/aerospace_defense.md`). These are the source files.
+*   **Individual Primer HTML Files:** Corresponding HTML versions of each primer are located in `primers/html/` (e.g., `primers/html/aerospace_defense.html`). These are typically generated from the Markdown files and are what `primers/index.html` links to for the full view.
+
+## 3. Specific Guidelines for Primers Content
+*   **Standard Sections:** Each primer `.md` file should ideally follow a consistent structure, including sections like:
+    1.  Industry Overview (History and Background, Key Segments)
+    2.  Long-Term Trends
+    3.  Business Cycles
+    4.  Key Credit Metrics (differentiated by sub-sector if applicable)
+    5.  Rating Criteria & Methodology Highlights
+    6.  Specific Risk Factors
+    7.  Monitoring & Underwriting Tips
+*   **Keywords:** When adding a new primer, ensure relevant keywords are added to its card in `primers/index.html` (in the `data-keywords` attribute) to aid searchability.
+*   **Clarity and Depth:** Primers should be detailed enough to be valuable for credit analysts and other finance professionals looking to understand an industry quickly.
+*   **Updating `primers/index.html`:**
+    *   When a new primer `.md` file is created:
+        1.  An HTML version (e.g., `primers/html/new_primer.html`) needs to be generated (currently a manual step, or if an agent can convert Markdown to HTML, that would be the process).
+        2.  A new "primer card" needs to be added to `primers/index.html` linking to this new HTML file and including a summary and keywords.
+        3.  The `primers/script.js` might need updates if the search or filter logic is complex and relies on specific structures.
+*   **Styling:** Individual primer HTML pages (`primers/html/*.html`) should ideally share a common stylesheet (perhaps `primers/styles.css` or a global one from `assets/css/`) for consistency.
+
+## 4. Linking
+*   Link key terms within primers to the `Global_Financial_Glossary.md`.
+*   Cross-reference primers if industries are closely related (e.g., Automotive and Industrials).
+
+## 5. Generating HTML from Markdown (Agent Workflow)
+If an agent is tasked with creating a new primer:
+1.  Create the main content in a `new_primer.md` file in the `primers/` directory.
+2.  If the agent possesses a reliable Markdown-to-HTML conversion tool (e.g., using `pandoc` or a library via `run_in_bash_session` if available, or an internal tool):
+    *   Convert `new_primer.md` to `primers/html/new_primer.html`.
+    *   Ensure the generated HTML is clean and well-formatted, ideally linking to shared CSS.
+3.  If direct conversion is not reliably available to the agent:
+    *   The agent should clearly note that the `primers/html/new_primer.html` file needs to be created/updated from the `new_primer.md` source, potentially by a human user or a separate process.
+4.  Update `primers/index.html` to include a card for the new primer, linking to `primers/html/new_primer.html`.
+
+Refer to the root `AGENTS.MD` for general guidelines.


### PR DESCRIPTION
- Created a standard HTML template (simple_viewer.css, index.html structure) that uses marked.js to render Markdown content.
- Deployed this template to 13 content directories lacking an index.html, providing sidebar navigation for local .md files and READMEs of immediate subdirectories.
- Added AGENTS.MD for the /primers directory.
- This enhances navigability and provides a consistent client-side viewing experience for Markdown-based content libraries.