### PR TITLE
fix: add missing comma in nav_data.js

### DIFF
--- a/js/nav_data.js
+++ b/js/nav_data.js
@@ -12,7 +12,8 @@ const navData = [
         text: "All Learning Paths",
         href: "Learning_Paths/index.html",
         type: "section_viewer"
-
+      },
+      {
         text: "CFA Study Hub",
         href: "CFA/index.html",
         type: "html_hub", // Interactive hub


### PR DESCRIPTION
This commit fixes a syntax error in `js/nav_data.js` by adding a missing comma. This was causing the navigation data to be parsed incorrectly, leading to a broken navigation menu.