### PR TITLE
feat: Add interactive prompt engineering notebooks

### DIFF
--- a/Interactive_Notebooks/Prompt_Engineering/01_Foundations_of_Prompt_Engineering.ipynb
+++ b/Interactive_Notebooks/Prompt_Engineering/01_Foundations_of_Prompt_Engineering.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Foundations of Prompt Engineering for Credit Analysts\n",
+    "\n",
+    "Welcome to this interactive notebook! The goal of this session is to introduce you to the fundamental principles of **prompt engineering**—the art of crafting effective inputs for Large Language Models (LLMs) to get the most accurate, relevant, and useful outputs for your work as a credit analyst."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup and Imports\n",
+    "\n",
+    "First, let's import the necessary libraries. We'll be using `ipywidgets` to create interactive elements like text boxes and buttons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "# --- LLM Simulation ---\n",
+    "# In a real environment, this would be a call to an actual LLM API.\n",
+    "# For this educational notebook, we'll simulate the LLM's response\n",
+    "# to demonstrate the principles of prompt engineering.\n",
+    "\n",
+    "def ask_llm(prompt):\n",
+    "    \"\"\"Simulates a call to a Large Language Model.\"\"\"\n",
+    "    prompt_lower = prompt.lower()\n",
+    "    \n",
+    "    # Rule-based responses for demonstration\n",
+    "    if 'credit analyst' in prompt_lower and 'key risks' in prompt_lower:\n",
+    "        return \"**Response:** Based on the provided financial statements, the key risks are: 1) High leverage with a Debt-to-EBITDA ratio of 5.5x, 2) Declining margins in the core business segment, and 3) Significant customer concentration with 40% of revenue from a single client.\"\n",
+    "    elif 'summarize' in prompt_lower and 'report' in prompt_lower:\n",
+    "        return \"**Response:** The report discusses the company's financial performance.\"\n",
+    "    elif 'tree of thought' in prompt_lower:\n",
+    "        return \"**Response:** Tree of Thoughts is an advanced technique. This notebook covers the foundations. Please see the next notebook for more on this.\"\n",
+    "    else:\n",
+    "        return \"**Response:** The model's response is generic because the prompt was not specific enough. Please try again with more context or a clearer role.\"\n",
+    "\n",
+    "print(\"Setup complete. The 'ask_llm' function is now available for use.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. The Core Principles of Prompting\n",
+    "\n",
+    "Effective prompting boils down to a few key principles. We'll explore them one by one with interactive examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Principle 1: Clarity and Specificity\n",
+    "\n",
+    "Vague prompts lead to vague answers. The more specific your request, the better the result.\n",
+    "\n",
+    "**Bad Prompt:** `Summarize the report.`\n",
+    "**Good Prompt:** `Summarize the key findings of the attached credit report, focusing on the company's liquidity position.`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt_input = widgets.Textarea(\n",
+    "    value='Summarize the report.',\n",
+    "    placeholder='Type your prompt here',\n",
+    "    description='Prompt:',\n",
+    "    layout={'width': '100%', 'height': '80px'}\n",
+    ")\n",
+    "\n",
+    "submit_button = widgets.Button(description=\"Ask LLM\")\n",
+    "output_area = widgets.Output()\n",
+    "\n",
+    "def on_submit_clicked(b):\n",
+    "    with output_area:\n",
+    "        output_area.clear_output()\n",
+    "        response = ask_llm(prompt_input.value)\n",
+    "        display(Markdown(response))\n",
+    "\n",
+    "submit_button.on_click(on_submit_clicked)\n",
+    "\n",
+    "display(prompt_input, submit_button, output_area)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Principle 2: Provide Context\n",
+    "\n",
+    "The LLM doesn't know what you know. Provide the necessary context for the task.\n",
+    "\n",
+    "**Bad Prompt:** `Is the company's debt level appropriate?`\n",
+    "**Good Prompt:** `The company operates in the cyclical manufacturing industry where the average Debt-to-EBITDA ratio is 3.0x. The company's current Debt-to-EBITDA ratio is 5.5x. Is the company's debt level appropriate?`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Principle 3: Use Role-Playing\n",
+    "\n",
+    "Assigning a role to the LLM helps it adopt the right perspective and tone.\n",
+    "\n",
+    "**Bad Prompt:** `What are the risks?`\n",
+    "**Good Prompt:** `You are a skeptical credit analyst. What are the key risks of this investment from a lender's perspective?`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt_input_2 = widgets.Textarea(\n",
+    "    value='You are a credit analyst. Summarize the key risks in the report.',\n",
+    "    placeholder='Type your prompt here',\n",
+    "    description='Prompt:',\n",
+    "    layout={'width': '100%', 'height': '80px'}\n",
+    ")\n",
+    "\n",
+    "submit_button_2 = widgets.Button(description=\"Ask LLM\")\n",
+    "output_area_2 = widgets.Output()\n",
+    "\n",
+    "def on_submit_clicked_2(b):\n",
+    "    with output_area_2:\n",
+    "        output_area_2.clear_output()\n",
+    "        response = ask_llm(prompt_input_2.value)\n",
+    "        display(Markdown(response))\n",
+    "\n",
+    "submit_button_2.on_click(on_submit_clicked_2)\n",
+    "\n",
+    "display(prompt_input_2, submit_button_2, output_area_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Conclusion\n",
+    "\n",
+    "You've now learned the foundational principles of prompt engineering. By writing clear, specific prompts with context and assigning a role to the AI, you can significantly improve the quality of the responses you receive.\n",
+    "\n",
+    "In the next notebook, we will explore advanced techniques like Chain-of-Thought and Tree of Thoughts to tackle more complex analytical tasks."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Interactive_Notebooks/Prompt_Engineering/02_Advanced_Prompting_Techniques.ipynb
+++ b/Interactive_Notebooks/Prompt_Engineering/02_Advanced_Prompting_Techniques.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Prompting Techniques for Credit Analysts\n",
+    "\n",
+    "In this notebook, we'll explore advanced prompting techniques that allow you to tackle more complex analytical tasks. These methods will help you guide the LLM's reasoning process, leading to more accurate and insightful results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup and Imports\n",
+    "\n",
+    "As before, we'll import the necessary libraries and use a simulated LLM function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display, Markdown\n",
+    "import json\n",
+    "\n",
+    "# --- LLM Simulation (Advanced) ---\n",
+    "def ask_llm_advanced(prompt):\n",
+    "    \"\"\"Simulates a call to a Large Language Model for advanced techniques.\"\"\"\n",
+    "    prompt_lower = prompt.lower()\n",
+    "\n",
+    "    if 'chain of thought' in prompt_lower or 'step-by-step' in prompt_lower:\n",
+    "        return \"\"\"**Chain-of-Thought Response:**\n",
+    "1.  **EBITDA Calculation:** Revenue (100M) - COGS (60M) - OpEx (20M) = 20M.\n",
+    "2.  **Debt Service Calculation:** Principal (10M) + Interest (5M) = 15M.\n",
+    "3.  **DSCR Calculation:** EBITDA (20M) / Debt Service (15M) = 1.33x.\n",
+    "**Final Answer:** The DSCR is 1.33x.\"\"\"\n",
+    "    elif 'few-shot' in prompt_lower:\n",
+    "        # This is a simplified simulation. A real implementation would parse the examples.\n",
+    "        return \"\"\"**Few-Shot Response:**\n",
+    "Based on the examples provided, here is the extracted information in JSON format:\n",
+    "```json\n",
+    "{\n",
+    "  \\\"Risk_Type\\\": \\\"Market\\\",\n",
+    "  \\\"Factor\\\": \\\"Interest Rate Risk\\\"\n",
+    "}\n",
+    "```\"\"\"\n",
+    "    elif 'tree of thoughts' in prompt_lower:\n",
+    "        return \"\"\"**Tree of Thoughts Response:**\n",
+    "**Path 1: Aggressive Cost Cutting**\n",
+    "*   Pros: Immediate margin improvement.\n",
+    "*   Cons: Potential impact on quality and employee morale.\n",
+    "**Path 2: Revenue Diversification**\n",
+    "*   Pros: Reduced customer concentration risk.\n",
+    "*   Cons: High initial investment, long time to see results.\n",
+    "**Recommendation:** Path 1 is recommended for short-term stability, but Path 2 should be explored for long-term sustainability.\"\"\"\n",
+    "    else:\n",
+    "        return \"**Response:** Please use a prompt that demonstrates an advanced technique (Chain of Thought, Few-Shot, or Tree of Thoughts).\"\n",
+    "\n",
+    "print(\"Setup complete. The 'ask_llm_advanced' function is now available.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Advanced Technique: Chain-of-Thought (CoT) Prompting\n",
+    "\n",
+    "CoT prompts instruct the LLM to think step-by-step, which is crucial for multi-step calculations.\n",
+    "\n",
+    "**Prompt Example:** `Calculate the DSCR for the company. Show your work step-by-step. Use Chain of Thought.`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cot_prompt_input = widgets.Textarea(\n",
+    "    value='Calculate the DSCR for the company. Show your work step-by-step. Use Chain of Thought.',\n",
+    "    placeholder='Type your CoT prompt here',\n",
+    "    description='CoT Prompt:',\n",
+    "    layout={'width': '100%', 'height': '80px'}\n",
+    ")\n",
+    "\n",
+    "cot_submit_button = widgets.Button(description=\"Ask LLM\")\n",
+    "cot_output_area = widgets.Output()\n",
+    "\n",
+    "def on_cot_submit_clicked(b):\n",
+    "    with cot_output_area:\n",
+    "        cot_output_area.clear_output()\n",
+    "        response = ask_llm_advanced(cot_prompt_input.value)\n",
+    "        display(Markdown(response))\n",
+    "\n",
+    "cot_submit_button.on_click(on_cot_submit_clicked)\n",
+    "\n",
+    "display(cot_prompt_input, cot_submit_button, cot_output_area)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Advanced Technique: Few-Shot Prompting\n",
+    "\n",
+    "Few-shot prompts provide examples to the LLM to guide its output format.\n",
+    "\n",
+    "**Prompt Example:** `You are a data extraction bot. Here are some examples:\\nExample 1: Input: \\\"The company is exposed to currency risk.\\\" Output: {\\\"Risk_Type\\\": \\\"Market\\\", \\\"Factor\\\": \\\"Currency Risk\\\"}\\n\\nNow, process this text: \\\"The company has high interest rate risk.\\\" Use Few-Shot.`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_prompt_input = widgets.Textarea(\n",
+    "    value='You are a data extraction bot. Here are some examples... Use Few-Shot.',\n",
+    "    placeholder='Type your Few-Shot prompt here',\n",
+    "    description='FS Prompt:',\n",
+    "    layout={'width': '100%', 'height': '120px'}\n",
+    ")\n",
+    "\n",
+    "fs_submit_button = widgets.Button(description=\"Ask LLM\")\n",
+    "fs_output_area = widgets.Output()\n",
+    "\n",
+    "def on_fs_submit_clicked(b):\n",
+    "    with fs_output_area:\n",
+    "        fs_output_area.clear_output()\n",
+    "        response = ask_llm_advanced(fs_prompt_input.value)\n",
+    "        display(Markdown(response))\n",
+    "\n",
+    "fs_submit_button.on_click(on_fs_submit_clicked)\n",
+    "\n",
+    "display(fs_prompt_input, fs_submit_button, fs_output_area)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Advanced Technique: Tree of Thoughts (ToT) Prompting\n",
+    "\n",
+    "ToT prompts encourage the LLM to explore multiple reasoning paths and then choose the best one.\n",
+    "\n",
+    "**Prompt Example:** `Develop three strategies to improve the company's liquidity. For each, list pros and cons. Finally, recommend the best strategy. Use Tree of Thoughts.`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tot_prompt_input = widgets.Textarea(\n",
+    "    value='Develop three strategies to improve liquidity. Use Tree of Thoughts.',\n",
+    "    placeholder='Type your ToT prompt here',\n",
+    "    description='ToT Prompt:',\n",
+    "    layout={'width': '100%', 'height': '80px'}\n",
+    ")\n",
+    "\n",
+    "tot_submit_button = widgets.Button(description=\"Ask LLM\")\n",
+    "tot_output_area = widgets.Output()\n",
+    "\n",
+    "def on_tot_submit_clicked(b):\n",
+    "    with tot_output_area:\n",
+    "        tot_output_area.clear_output()\n",
+    "        response = ask_llm_advanced(tot_prompt_input.value)\n",
+    "        display(Markdown(response))\n",
+    "\n",
+    "tot_submit_button.on_click(on_tot_submit_clicked)\n",
+    "\n",
+    "display(tot_prompt_input, tot_submit_button, tot_output_area)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Conclusion\n",
+    "\n",
+    "By mastering these advanced techniques, you can unlock new capabilities for AI-powered financial analysis. Experiment with these methods to see how they can enhance your workflow."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Interactive_Notebooks/Prompt_Engineering/README.md
+++ b/Interactive_Notebooks/Prompt_Engineering/README.md
@@ -1,0 +1,22 @@
+# Interactive Notebooks for Prompt Engineering
+
+Welcome to the Prompt Engineering module! This set of notebooks is designed to provide a hands-on introduction to prompt engineering for credit analysts.
+
+## Notebooks in this Module
+
+1.  **[01_Foundations_of_Prompt_Engineering.ipynb](./01_Foundations_of_Prompt_Engineering.ipynb)**
+    *   This notebook covers the fundamental principles of prompt engineering, including clarity, context, and role-playing. It features interactive widgets to help you practice and understand these concepts.
+
+2.  **[02_Advanced_Prompting_Techniques.ipynb](./02_Advanced_Prompting_Techniques.ipynb)**
+    *   This notebook explores advanced techniques like Chain-of-Thought, Few-Shot Prompting, and Tree of Thoughts. It provides interactive examples to help you master these powerful methods for complex analytical tasks.
+
+## How to Use
+
+To get the most out of these notebooks, you should:
+
+1.  **Download the `.ipynb` files** from the links above.
+2.  **Run the notebooks in a Jupyter environment** (like JupyterLab or Google Colab).
+3.  **Install the necessary libraries:** `ipywidgets` is required for the interactive elements. You can install it with `pip install ipywidgets`.
+4.  **Experiment!** Change the prompts, try different inputs, and see how the "LLM" responds.
+
+These notebooks are designed to be a starting point. We encourage you to build on these concepts and apply them to your own work.

--- a/Interactive_Notebooks/Prompt_Engineering/index.html
+++ b/Interactive_Notebooks/Prompt_Engineering/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prompt Engineering Notebooks</title>
+    <link rel="stylesheet" href="../../assets/css/main.css">
+    <link rel="stylesheet" href="../../css/global_nav.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+    <div id="global-nav-placeholder"></div>
+    <div class="content-container">
+        <div id="markdown-content"></div>
+    </div>
+
+    <script src="../../js/nav_data.js" defer></script>
+    <script src="../../js/global_nav.js" defer></script>
+    <script>
+        fetch('README.md')
+            .then(response => response.text())
+            .then(text => {
+                document.getElementById('markdown-content').innerHTML = marked.parse(text);
+            });
+    </script>
+</body>
+</html>

--- a/Interactive_Notebooks/README.md
+++ b/Interactive_Notebooks/README.md
@@ -35,6 +35,10 @@ This section acts as a catalog for all interactive Jupyter Notebook modules. Eac
     *   **Guide & Overview:** [./CFA_Quant_Methods/README.md](./CFA_Quant_Methods/README.md)
     *   *Description: Notebooks related to quantitative concepts from the CFA curriculum.* *(Content to be developed)*
 
+*   **Prompt Engineering:**
+    *   **Guide & Overview:** [./Prompt_Engineering/README.md](./Prompt_Engineering/README.md)
+    *   *Description: A hands-on guide to prompt engineering for credit analysts, from foundational principles to advanced techniques.*
+
 *   **Financial Modeling & Valuation:**
     *   **Guide & Overview:** [./Financial_Modeling/README.md](./Financial_Modeling/README.md)
     *   **Notebook File:** [EquityValuationNotebook.ipynb](./Financial_Modeling/EquityValuationNotebook.ipynb)

--- a/Interactive_Notebooks/index.html
+++ b/Interactive_Notebooks/index.html
@@ -89,6 +89,11 @@
                         <p class="text-sm text-slate-600 mb-4 flex-grow">An interactive guide to financial ratio analysis using Python.</p>
                         <a href="/global_markdown_viewer.html?mdfile=Interactive_Notebooks/Financial_Analysis/README.md" class="card-link">View Guide</a>
                     </div>
+                    <div class="content-card">
+                        <h3 class="font-semibold text-xl mb-3 text-slate-800">Prompt Engineering</h3>
+                        <p class="text-sm text-slate-600 mb-4 flex-grow">A hands-on guide to prompt engineering for credit analysts, from foundational principles to advanced techniques.</p>
+                        <a href="/global_markdown_viewer.html?mdfile=Interactive_Notebooks/Prompt_Engineering/README.md" class="card-link">View Guide</a>
+                    </div>
                 </div>
             </div>
         </main>

--- a/js/nav_data.js
+++ b/js/nav_data.js
@@ -1839,6 +1839,28 @@ const navData = [
         "type": "html_hub"
       },
       {
+        "text": "Prompt Engineering",
+        "type": "category",
+        "children": [
+          {
+            "text": "README",
+            "href": "Interactive_Notebooks/Prompt_Engineering/README.md",
+            "type": "markdown_viewer",
+            "viewer": "global"
+          },
+          {
+            "text": "01 Foundations of Prompt Engineering",
+            "href": "Interactive_Notebooks/Prompt_Engineering/01_Foundations_of_Prompt_Engineering.ipynb",
+            "type": "jupyter_guide"
+          },
+          {
+            "text": "02 Advanced Prompting Techniques",
+            "href": "Interactive_Notebooks/Prompt_Engineering/02_Advanced_Prompting_Techniques.ipynb",
+            "type": "jupyter_guide"
+          }
+        ]
+      },
+      {
         "text": "Cfa Quant Methods",
         "type": "category",
         "children": [


### PR DESCRIPTION
This commit introduces a new section for prompt engineering in the `Interactive_Notebooks` directory. It includes two new notebooks:

- `01_Foundations_of_Prompt_Engineering.ipynb`: Covers the basic principles of prompt engineering with interactive examples.
- `02_Advanced_Prompting_Techniques.ipynb`: Explores advanced techniques like Chain-of-Thought, Few-Shot Prompting, and Tree of Thoughts.

The notebooks are self-contained and use `ipywidgets` to provide an interactive learning experience for credit analysts.

The commit also includes:
- A `README.md` guide for the new notebooks.
- An `index.html` file to display the guide.
- Updates to the main `Interactive_Notebooks` documentation and global navigation to make the new content discoverable.