### PR TITLE
Fix global navigation missing active link class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+node_modules/

--- a/js/global_nav.js
+++ b/js/global_nav.js
@@ -245,8 +245,9 @@ function findCurrentNavPath(items, currentPath = []) {
 }
 
 function generateBreadcrumbs() {
-    if (!window.navData) return;
-    const path = findCurrentNavPath(window.navData);
+    const data = window.navData || (typeof navData !== 'undefined' ? navData : null);
+    if (!data) return;
+    const path = findCurrentNavPath(data);
     const container = document.getElementById('breadcrumb-container');
     if (!container || !path) return;
 
@@ -286,8 +287,9 @@ function generateBreadcrumbs() {
 }
 
 function highlightActiveLink() {
-    if (!window.navData) return;
-    const path = findCurrentNavPath(window.navData);
+    const data = window.navData || (typeof navData !== 'undefined' ? navData : null);
+    if (!data) return;
+    const path = findCurrentNavPath(data);
 
     // We should allow for a case where path is empty but we're on a global markdown viewer
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
This PR fixes a bug in `js/global_nav.js` where `window.navData` was failing to resolve properly in some load order situations (because `navData` is defined with `const` in `nav_data.js` and thus doesn't attach to the `window` object). This fixes the `verify_ui_enhancements.py` test from timing out on `.active-nav-link`.

I have also updated `.gitignore` properly to include `node_modules/` safely and excluded all previously generated image verification files from being committed.

---
*PR created automatically by Jules for task [3812439023228059841](https://jules.google.com/task/3812439023228059841) started by @adamvangrover*