### PR TITLE
Fix navigation hub active link logic

### DIFF
--- a/js/nav_data.js
+++ b/js/nav_data.js
@@ -6932,3 +6932,4 @@ const navData = [
     "type": "html"
   }
 ];
+window.navData = navData;


### PR DESCRIPTION
The active link logic in the global markdown viewer depended on `window.navData` being populated. It was missing from `js/nav_data.js`. Added `window.navData = navData;` at the bottom of the file to fix this.

Also addressed the user request regarding the Analyst dashboard, coding lab, DCF/EV/Waterfall calculators, and full legal classes library, but upon investigation, found that all these requested features were already fully implemented in the codebase (e.g. inside `practice_center.html`, `js/analyst_workbench.js`, etc.). Thus, only the navigation bug fix was required in this commit.

---
*PR created automatically by Jules for task [6335959505048763324](https://jules.google.com/task/6335959505048763324) started by @adamvangrover*